### PR TITLE
021125 - Add Starwars ACD, Starwars factions, and More Cannons support

### DIFF
--- a/mod.rules
+++ b/mod.rules
@@ -192,6 +192,374 @@ Actions
 	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/2886141879/parts/modular_missile_loader/modular_missile_loader.rules>/Part/Components"; BaseToAdd = &<automation_components_modular_missiles/modular_missile_loader.rules>}
 	
 	//------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+	// ------------------------------------------------------------
+	// More Deck Cannons for 0.22
+	// https://steamcommunity.com/sharedfiles/filedetails/?id=3052680147
+
+	// 4 crew ------------------------------------------------------------
+	// SteamLibrary\steamapps\workshop\content\799600\3052680147\3_152mm\3_152mm.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3052680147/3_152mm/3_152mm.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3052680147/3_152mm/3_152mm.rules>/Part/Stats/CrewRequired"; With = 4}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3052680147/3_152mm/3_152mm.rules>/Part/Components"; BaseToAdd = &<more_cannons/3_152mm.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3052680147\4_130mm\4_130mm.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3052680147/4_130mm/4_130mm.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3052680147/4_130mm/4_130mm.rules>/Part/Stats/CrewRequired"; With = 4}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3052680147/4_130mm/4_130mm.rules>/Part/Components"; BaseToAdd = &<more_cannons/4_130mm.rules>}
+
+	// 6 crew ------------------------------------------------------------
+	// SteamLibrary\steamapps\workshop\content\799600\3052680147\2_381mm\2_381mm.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3052680147/2_381mm/2_381mm.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3052680147/2_381mm/2_381mm.rules>/Part/Stats/CrewRequired"; With = 6}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3052680147/2_381mm/2_381mm.rules>/Part/Components"; BaseToAdd = &<more_cannons/2_381mm.rules>}
+
+	// 8 crew ------------------------------------------------------------
+	// SteamLibrary\steamapps\workshop\content\799600\3052680147\2_420mm\2_420mm.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3052680147/2_420mm/2_420mm.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3052680147/2_420mm/2_420mm.rules>/Part/Stats/CrewRequired"; With = 8}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3052680147/2_420mm/2_420mm.rules>/Part/Components"; BaseToAdd = &<more_cannons/2_420mm.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3052680147\2_420mm_b\2_420mm_b.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3052680147/2_420mm_b/2_420mm_b.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3052680147/2_420mm_b/2_420mm_b.rules>/Part/Stats/CrewRequired"; With = 8}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3052680147/2_420mm_b/2_420mm_b.rules>/Part/Components"; BaseToAdd = &<more_cannons/2_420mm_b.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3052680147\2_510mm\2_510mm.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3052680147/2_510mm/2_510mm.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3052680147/2_510mm/2_510mm.rules>/Part/Stats/CrewRequired"; With = 8}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3052680147/2_510mm/2_510mm.rules>/Part/Components"; BaseToAdd = &<more_cannons/2_510mm.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3052680147\3_460mm\3_460mm.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3052680147/3_460mm/3_460mm.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3052680147/3_460mm/3_460mm.rules>/Part/Stats/CrewRequired"; With = 8}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3052680147/3_460mm/3_460mm.rules>/Part/Components"; BaseToAdd = &<more_cannons/3_460mm.rules>}
+
+	// 10 crew ------------------------------------------------------------
+	// SteamLibrary\steamapps\workshop\content\799600\3052680147\4_431mm\4_431mm.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3052680147/4_431mm/4_431mm.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3052680147/4_431mm/4_431mm.rules>/Part/Stats/CrewRequired"; With = 10}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3052680147/4_431mm/4_431mm.rules>/Part/Components"; BaseToAdd = &<more_cannons/4_431mm.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3052680147\6_406mm\6_406mm.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3052680147/6_406mm/6_406mm.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3052680147/6_406mm/6_406mm.rules>/Part/Stats/CrewRequired"; With = 10}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3052680147/6_406mm/6_406mm.rules>/Part/Components"; BaseToAdd = &<more_cannons/6_406mm.rules>}
+	
+	// 20 crew (wow) ------------------------------------------------------------
+	// SteamLibrary\steamapps\workshop\content\799600\3052680147\2_800mm\2_800mm.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3052680147/2_800mm/2_800mm.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3052680147/2_800mm/2_800mm.rules>/Part/Stats/CrewRequired"; With = 20}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3052680147/2_800mm/2_800mm.rules>/Part/Components"; BaseToAdd = &<more_cannons/2_800mm.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3052680147\3_800mm\3_800mm.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3052680147/3_800mm/3_800mm.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3052680147/3_800mm/3_800mm.rules>/Part/Stats/CrewRequired"; With = 20}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3052680147/3_800mm/3_800mm.rules>/Part/Components"; BaseToAdd = &<more_cannons/3_800mm.rules>}
+
+	// ------------------------------------------------------------
+	
+	//starwars FACTIONS
+	// https://steamcommunity.com/sharedfiles/filedetails/?id=3121346591
+
+	// SteamLibrary\steamapps\workshop\content\799600\3121346591\parts\Weapons\droid_turret\droid_turret.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3121346591/parts/Weapons/droid_turret/droid_turret.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3121346591/parts/Weapons/droid_turret/droid_turret.rules>/Part/Stats/CrewRequired"; With = 1}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3121346591/parts/Weapons/droid_turret/droid_turret.rules>/Part/Components"; BaseToAdd = &<starwars/droid_turret.rules>}
+	
+	//starwars ACD 
+	// https://steamcommunity.com/sharedfiles/filedetails/?id=3119349707
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\missile_launchers\missile_launcher_medium\missile_launcher.rules
+	// Missile launcher (2 crew)
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/missile_launchers/missile_launcher_medium/missile_launcher.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/missile_launchers/missile_launcher_medium/missile_launcher.rules>/Part/Stats/CrewRequired"; With = 2}	
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/missile_launchers/missile_launcher_medium/missile_launcher.rules>/Part/Components"; BaseToAdd = &<starwars/missile_launcher.rules>}
+
+	// Star Wars Bridge (13 Crew)
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\control_rooms\bridges\Republic_Empire\bridge.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/control_rooms/bridges/Republic_Empire/bridge.rules>/Part/Components/PartCrewCaptian"}
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/control_rooms/bridges/Republic_Empire/bridge.rules>/Part/Components/PartCrewNavigatorsL"}
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/control_rooms/bridges/Republic_Empire/bridge.rules>/Part/Components/PartCrewNavigatorsR"}
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/control_rooms/bridges/Republic_Empire/bridge.rules>/Part/Components/PartCrewOfficers"}
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/control_rooms/bridges/Republic_Empire/bridge.rules>/Part/Components/IsOperational"}
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/control_rooms/bridges/Republic_Empire/bridge.rules>/Part/Components/Indicators"}
+	// Replace the total CrewRequired value
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/control_rooms/bridges/Republic_Empire/bridge.rules>/Part/Stats/CrewRequired"; With = 12}
+	// Add the new modded PartCrew system
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/control_rooms/bridges/Republic_Empire/bridge.rules>/Part/Components"; BaseToAdd = &<starwars/bridge.rules>}
+
+	// Star Wars War Room (8 Crew)
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\control_rooms\warroom\WarRoom.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/control_rooms/warroom/WarRoom.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/control_rooms/warroom/WarRoom.rules>/Part/Stats/CrewRequired"; With = 8}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/control_rooms/warroom/WarRoom.rules>/Part/Components"; BaseToAdd = &<starwars/WarRoom.rules>}
+
+	// 1 crew 
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\cannons\FixedHeavyLaserCannon\fixedheavylaser.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/cannons/FixedHeavyLaserCannon/fixedheavylaser.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/cannons/FixedHeavyLaserCannon/fixedheavylaser.rules>/Part/Stats/CrewRequired"; With = 1}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/cannons/FixedHeavyLaserCannon/fixedheavylaser.rules>/Part/Components"; BaseToAdd = &<starwars/fixedheavylaser.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\missile_launchers\missile_launcher_small\missile_launcher_small_tl_backup.rules
+	// {IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/missile_launchers/missile_launcher_small/missile_launcher_small_tl_backup.rules>/Part/Components/PartCrew"}
+	// {IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/missile_launchers/missile_launcher_small/missile_launcher_small_tl_backup.rules>/Part/Stats/CrewRequired"; With = 1}
+	// {IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/missile_launchers/missile_launcher_small/missile_launcher_small_tl_backup.rules>/Part/Components"; BaseToAdd = &<starwars/missile_launcher_small_tl_backup.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\missile_launchers\missile_launcher_small\missile_launcher_small.rules
+	// {IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/missile_launchers/missile_launcher_small/missile_launcher_small.rules>/Part/Components/PartCrew"}
+	// {IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/missile_launchers/missile_launcher_small/missile_launcher_small.rules>/Part/Stats/CrewRequired"; With = 1}
+	// {IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/missile_launchers/missile_launcher_small/missile_launcher_small.rules>/Part/Components"; BaseToAdd = &<starwars/missile_launcher_small.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\small\Tiny_TL_Burst\swturret_A.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/small/Tiny_TL_Burst/swturret_A.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/small/Tiny_TL_Burst/swturret_A.rules>/Part/Stats/CrewRequired"; With = 1}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/small/Tiny_TL_Burst/swturret_A.rules>/Part/Components"; BaseToAdd = &<starwars/swturret_A.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\small\Tiny_TL_Heavy\swturret_B.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/small/Tiny_TL_Heavy/swturret_B.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/small/Tiny_TL_Heavy/swturret_B.rules>/Part/Stats/CrewRequired"; With = 1}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/small/Tiny_TL_Heavy/swturret_B.rules>/Part/Components"; BaseToAdd = &<starwars/swturret_B.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\small\Tiny_TL_Rapid\swturret_C.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/small/Tiny_TL_Rapid/swturret_C.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/small/Tiny_TL_Rapid/swturret_C.rules>/Part/Stats/CrewRequired"; With = 1}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/small/Tiny_TL_Rapid/swturret_C.rules>/Part/Components"; BaseToAdd = &<starwars/swturret_C.rules>}
+
+
+	// 2 crew 
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\ions\IonCannon_Heavy\heavy_ion_cannon_switchable.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/ions/IonCannon_Heavy/heavy_ion_cannon_switchable.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/ions/IonCannon_Heavy/heavy_ion_cannon_switchable.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/ions/IonCannon_Heavy/heavy_ion_cannon_switchable.rules>/Part/Components"; BaseToAdd = &<starwars/heavy_ion_cannon_switchable.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\ions\IonCannon_Medium\medium_ion_cannon.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/ions/IonCannon_Medium/medium_ion_cannon.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/ions/IonCannon_Medium/medium_ion_cannon.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/ions/IonCannon_Medium/medium_ion_cannon.rules>/Part/Components"; BaseToAdd = &<starwars/medium_ion_cannon.rules>}
+
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Medium_Quad/medium_turbolaser_quad_switchable.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Medium_Quad/medium_turbolaser_quad_switchable.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Medium_Quad/medium_turbolaser_quad_switchable.rules>/Part/Components"; BaseToAdd = &<starwars/medium_turbolaser_quad_switchable.rules>}
+
+	// cis_turbolaser_switchable.rules \799600\3119349707\ships\terran\weapons\turbolasers\Turbolasers_Big\cis_turbolaser_switchable.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Big/cis_turbolaser_switchable.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Big/cis_turbolaser_switchable.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Big/cis_turbolaser_switchable.rules>/Part/Components"; BaseToAdd = &<starwars/cis_turbolaser_switchable.rules>}		
+
+	// falcon_laser_cannon.rules \799600\3119349707\ships\terran\weapons\special\FalconLaser\falcon_laser_cannon.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/special/FalconLaser/falcon_laser_cannon.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/special/FalconLaser/falcon_laser_cannon.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/special/FalconLaser/falcon_laser_cannon.rules>/Part/Components"; BaseToAdd = &<starwars/falcon_laser_cannon.rules>}
+
+	// heavy_turbolaser_switchable.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Big/heavy_turbolaser_switchable.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Big/heavy_turbolaser_switchable.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Big/heavy_turbolaser_switchable.rules>/Part/Components"; BaseToAdd = &<starwars/heavy_turbolaser_switchable.rules>}
+
+	// imperial_turbolaser_switchable.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Big/imperial_turbolaser_switchable.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Big/imperial_turbolaser_switchable.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Big/imperial_turbolaser_switchable.rules>/Part/Components"; BaseToAdd = &<starwars/imperial_turbolaser_switchable.rules>}
+
+	// light_turbolaser_switchable.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Light/light_turbolaser_switchable.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Light/light_turbolaser_switchable.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Light/light_turbolaser_switchable.rules>/Part/Components"; BaseToAdd = &<starwars/light_turbolaser_switchable.rules>}
+
+	// medium_triple_turbolaser.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Triple/medium_triple_turbolaser.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Triple/medium_triple_turbolaser.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Triple/medium_triple_turbolaser.rules>/Part/Components"; BaseToAdd = &<starwars/medium_triple_turbolaser.rules>}
+
+	// med_turbolaser_switchable.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Med/med_turbolaser_switchable.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Med/med_turbolaser_switchable.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Med/med_turbolaser_switchable.rules>/Part/Components"; BaseToAdd = &<starwars/med_turbolaser_switchable.rules>}
+
+	// republic_turbolaser_switchable.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Big/republic_turbolaser_switchable.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Big/republic_turbolaser_switchable.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Big/republic_turbolaser_switchable.rules>/Part/Components"; BaseToAdd = &<starwars/republic_turbolaser_switchable.rules>}
+
+	// small_triple_turbolaser.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Triple/small_triple_turbolaser.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Triple/small_triple_turbolaser.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Triple/small_triple_turbolaser.rules>/Part/Components"; BaseToAdd = &<starwars/small_triple_turbolaser.rules>}
+
+	// turbolaser_ball_small01.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Small/turbolaser_ball_small01.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Small/turbolaser_ball_small01.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Small/turbolaser_ball_small01.rules>/Part/Components"; BaseToAdd = &<starwars/turbolaser_ball_small01.rules>}
+
+	// turbolaser_ball_small02.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Small/turbolaser_ball_small02.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Small/turbolaser_ball_small02.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Small/turbolaser_ball_small02.rules>/Part/Components"; BaseToAdd = &<starwars/turbolaser_ball_small02.rules>}
+
+	// turbolaser_ball_small03.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Small/turbolaser_ball_small03.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Small/turbolaser_ball_small03.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Small/turbolaser_ball_small03.rules>/Part/Components"; BaseToAdd = &<starwars/turbolaser_ball_small03.rules>}
+
+	// turbolaser_carronade.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Carronade/turbolaser_carronade.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Carronade/turbolaser_carronade.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Carronade/turbolaser_carronade.rules>/Part/Components"; BaseToAdd = &<starwars/turbolaser_carronade.rules>}
+
+	// turbolaser_flak_cannon01.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Flak_Cannon/turbolaser_flak_cannon01.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Flak_Cannon/turbolaser_flak_cannon01.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Flak_Cannon/turbolaser_flak_cannon01.rules>/Part/Components"; BaseToAdd = &<starwars/turbolaser_flak_cannon01.rules>}
+
+	// turbolaser_light_pd4.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Light/turbolaser_light_pd4.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Light/turbolaser_light_pd4.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Light/turbolaser_light_pd4.rules>/Part/Components"; BaseToAdd = &<starwars/turbolaser_light_pd4.rules>}
+
+	// turbolaser_med_LR01.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Med_LR01/turbolaser_med_LR01.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Med_LR01/turbolaser_med_LR01.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Med_LR01/turbolaser_med_LR01.rules>/Part/Components"; BaseToAdd = &<starwars/turbolaser_med_LR01.rules>}
+
+	// turbolaser_spinal_turret_2x3.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Spinal_Turret/turbolaser_spinal_turret_2x3.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Spinal_Turret/turbolaser_spinal_turret_2x3.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Spinal_Turret/turbolaser_spinal_turret_2x3.rules>/Part/Components"; BaseToAdd = &<starwars/turbolaser_spinal_turret_2x3.rules>}
+
+	// turbolaser_tower_triple01.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Tower/turbolaser_tower_triple01.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Tower/turbolaser_tower_triple01.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Tower/turbolaser_tower_triple01.rules>/Part/Components"; BaseToAdd = &<starwars/turbolaser_tower_triple01.rules>}
+
+	// xx9_turbolaser_switchable.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Big/xx9_turbolaser_switchable.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Big/xx9_turbolaser_switchable.rules>/Part/Stats/CrewRequired"; With = 2}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Big/xx9_turbolaser_switchable.rules>/Part/Components"; BaseToAdd = &<starwars/xx9_turbolaser_switchable.rules>}
+
+	// 3 crew 
+
+	// \799600\3119349707\ships\terran\weapons\turbolasers\Turbolasers_Ball_Medium\turbolaser_ball_med_roof_base.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Medium/turbolaser_ball_med_roof_base.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Medium/turbolaser_ball_med_roof_base.rules>/Part/Stats/CrewRequired"; With = 3}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Medium/turbolaser_ball_med_roof_base.rules>/Part/Components"; BaseToAdd = &<starwars/turbolaser_ball_med_roof_base.rules>}
+
+	// \799600\3119349707\ships\terran\weapons\turbolasers\Turbolasers_Ball_Medium\turbolaser_ball_med_side_base.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Medium/turbolaser_ball_med_side_base.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Medium/turbolaser_ball_med_side_base.rules>/Part/Stats/CrewRequired"; With = 3}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Medium/turbolaser_ball_med_side_base.rules>/Part/Components"; BaseToAdd = &<starwars/turbolaser_ball_med_side_base.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\utilities\mining_laser_huge\mining_laser_huge.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/utilities/mining_laser_huge/mining_laser_huge.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/utilities/mining_laser_huge/mining_laser_huge.rules>/Part/Stats/CrewRequired"; With = 3}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/utilities/mining_laser_huge/mining_laser_huge.rules>/Part/Components"; BaseToAdd = &<starwars/mining_laser_huge.rules>}
+
+	// 4 Crew
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\super\axial_superlaser\axial_superlaser.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/axial_superlaser/axial_superlaser.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/axial_superlaser/axial_superlaser.rules>/Part/Stats/CrewRequired"; With = 4}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/axial_superlaser/axial_superlaser.rules>/Part/Components"; BaseToAdd = &<starwars/axial_superlaser.rules>}
+
+	//H:\SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\super\deathstar_superlaser\deathstar_superlaser_sect2L.rules
+	// {IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/deathstar_superlaser/deathstar_superlaser_sect2L.rules>/Part/Components/PartCrew"}
+	// {IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/deathstar_superlaser/deathstar_superlaser_sect2L.rules>/Part/Stats/CrewRequired"; With = 4}
+	// {IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/deathstar_superlaser/deathstar_superlaser_sect2L.rules>/Part/Components"; BaseToAdd = &<starwars/deathstar_superlaser_sect2L.rules>}
+
+	//H:\SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\super\deathstar_superlaser\deathstar_superlaser_sect2R.rules
+	// {IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/deathstar_superlaser/deathstar_superlaser_sect2R.rules>/Part/Components/PartCrew"}
+	// {IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/deathstar_superlaser/deathstar_superlaser_sect2R.rules>/Part/Stats/CrewRequired"; With = 4}
+	// {IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/deathstar_superlaser/deathstar_superlaser_sect2R.rules>/Part/Components"; BaseToAdd = &<starwars/deathstar_superlaser_sect2R.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\super\deathstar_superlaser\deathstar_superlaser.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/deathstar_superlaser/deathstar_superlaser.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/deathstar_superlaser/deathstar_superlaser.rules>/Part/Stats/CrewRequired"; With = 4}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/deathstar_superlaser/deathstar_superlaser.rules>/Part/Components"; BaseToAdd = &<starwars/deathstar_superlaser.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\super\deathstar_superlaser2\DSLaser_core.rules
+	// {IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/deathstar_superlaser2/DSLaser_core.rules>/Part/Components/PartCrew"}
+	// {IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/deathstar_superlaser2/DSLaser_core.rules>/Part/Stats/CrewRequired"; With = 4}
+	// {IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/deathstar_superlaser2/DSLaser_core.rules>/Part/Components"; BaseToAdd = &<starwars/DSLaser_core.rules>}	
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\super\Heavy_Artillery_Turbolaser_SPHA_T\heavy_artillery_turbolaser_SPHA_T.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/Heavy_Artillery_Turbolaser_SPHA_T/heavy_artillery_turbolaser_SPHA_T.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/Heavy_Artillery_Turbolaser_SPHA_T/heavy_artillery_turbolaser_SPHA_T.rules>/Part/Stats/CrewRequired"; With = 4}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/Heavy_Artillery_Turbolaser_SPHA_T/heavy_artillery_turbolaser_SPHA_T.rules>/Part/Components"; BaseToAdd = &<starwars/heavy_artillery_turbolaser_SPHA_T.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\super\orbital_autocannon\orbital_autocannon.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/orbital_autocannon/orbital_autocannon.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/orbital_autocannon/orbital_autocannon.rules>/Part/Stats/CrewRequired"; With = 4}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/orbital_autocannon/orbital_autocannon.rules>/Part/Components"; BaseToAdd = &<starwars/orbital_autocannon.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\super\orbital_bombardment_particle_cannon\orbital_bombardment_particle_cannon.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/orbital_bombardment_particle_cannon/orbital_bombardment_particle_cannon.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/orbital_bombardment_particle_cannon/orbital_bombardment_particle_cannon.rules>/Part/Stats/CrewRequired"; With = 4}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/orbital_bombardment_particle_cannon/orbital_bombardment_particle_cannon.rules>/Part/Components"; BaseToAdd = &<starwars/orbital_bombardment_particle_cannon.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\super\superheavy_composite_beam_turbolaser\superheavy_composite_beam_turbolaser.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/superheavy_composite_beam_turbolaser/superheavy_composite_beam_turbolaser.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/superheavy_composite_beam_turbolaser/superheavy_composite_beam_turbolaser.rules>/Part/Stats/CrewRequired"; With = 4}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/super/superheavy_composite_beam_turbolaser/superheavy_composite_beam_turbolaser.rules>/Part/Components"; BaseToAdd = &<starwars/superheavy_composite_beam_turbolaser.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\turbolasers\Turbolasers_Ball_Large\turbolaser_ball_large_roof_base.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Large/turbolaser_ball_large_roof_base.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Large/turbolaser_ball_large_roof_base.rules>/Part/Stats/CrewRequired"; With = 4}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Large/turbolaser_ball_large_roof_base.rules>/Part/Components"; BaseToAdd = &<starwars/turbolaser_ball_large_roof_base.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\turbolasers\Turbolasers_Ball_Large\turbolaser_ball_large_side_base.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Large/turbolaser_ball_large_side_base.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Large/turbolaser_ball_large_side_base.rules>/Part/Stats/CrewRequired"; With = 4}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Large/turbolaser_ball_large_side_base.rules>/Part/Components"; BaseToAdd = &<starwars/turbolaser_ball_large_side_base.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\turbolasers\Turbolasers_Large\turbolaser_large_base.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Large/turbolaser_large_base.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Large/turbolaser_large_base.rules>/Part/Stats/CrewRequired"; With = 4}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Large/turbolaser_large_base.rules>/Part/Components"; BaseToAdd = &<starwars/turbolaser_large_base.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\turbolasers\Turbolasers_Medium\turbolaser_medium_base.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Medium/turbolaser_medium_base.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Medium/turbolaser_medium_base.rules>/Part/Stats/CrewRequired"; With = 4}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Medium/turbolaser_medium_base.rules>/Part/Components"; BaseToAdd = &<starwars/turbolaser_medium_base.rules>}
+
+	// 6 Crew
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\turbolasers\Turbolasers_Ball_Huge\turbolaser_ball_huge_roof_base.rules
+	// {IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Huge/turbolaser_ball_huge_roof_base.rules>/Part/Components/PartCrew"}
+	// {IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Huge/turbolaser_ball_huge_roof_base.rules>/Part/Stats/CrewRequired"; With = 6}
+	// {IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Huge/turbolaser_ball_huge_roof_base.rules>/Part/Components"; BaseToAdd = &<starwars/turbolaser_ball_huge_roof_base.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\turbolasers\Turbolasers_Ball_Huge\turbolaser_ball_huge_side_base.rules
+	// {IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Huge/turbolaser_ball_huge_side_base.rules>/Part/Components/PartCrew"}
+	// {IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Huge/turbolaser_ball_huge_side_base.rules>/Part/Stats/CrewRequired"; With = 6}
+	// {IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Ball_Huge/turbolaser_ball_huge_side_base.rules>/Part/Components"; BaseToAdd = &<starwars/turbolaser_ball_huge_side_base.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\turbolasers\Turbolasers_Medium_Quad\medium_turbolaser_quad03.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Medium_Quad/medium_turbolaser_quad03.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Medium_Quad/medium_turbolaser_quad03.rules>/Part/Stats/CrewRequired"; With = 6}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Medium_Quad/medium_turbolaser_quad03.rules>/Part/Components"; BaseToAdd = &<starwars/medium_turbolaser_quad03.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\turbolasers\Turbolasers_Octuple_Barbette\octuple_barbette_turbolaser.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Octuple_Barbette/octuple_barbette_turbolaser.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Octuple_Barbette/octuple_barbette_turbolaser.rules>/Part/Stats/CrewRequired"; With = 6}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Octuple_Barbette/octuple_barbette_turbolaser.rules>/Part/Components"; BaseToAdd = &<starwars/octuple_barbette_turbolaser.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3119349707\ships\terran\weapons\turbolasers\Turbolasers_Octuple_Barbette\quad_barbette_turbolaser.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Octuple_Barbette/quad_barbette_turbolaser.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Octuple_Barbette/quad_barbette_turbolaser.rules>/Part/Stats/CrewRequired"; With = 6}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3119349707/ships/terran/weapons/turbolasers/Turbolasers_Octuple_Barbette/quad_barbette_turbolaser.rules>/Part/Components"; BaseToAdd = &<starwars/quad_barbette_turbolaser.rules>}
+	
+	// SteamLibrary\steamapps\workshop\content\799600\3019500035\engineering_bay\engineering_bay.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3019500035/engineering_bay/engineering_bay.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3019500035/engineering_bay/engineering_bay.rules>/Part/Stats/CrewRequired"; With = 4}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3019500035/engineering_bay/engineering_bay.rules>/Part/Components"; BaseToAdd = &<starwars/engineering_bay_ai.rules>}
+
+	// SteamLibrary\steamapps\workshop\content\799600\3023201707\large_impulse_drive\large_impulse_drive.rules
+	{IgnoreIfNotExisting = true; Action = Remove; Remove = "<../../../workshop/content/799600/3023201707/large_impulse_drive/large_impulse_drive.rules>/Part/Components/PartCrew"}
+	{IgnoreIfNotExisting = true; Action = Replace; Replace = "<../../../workshop/content/799600/3023201707/large_impulse_drive/large_impulse_drive.rules>/Part/Stats/CrewRequired"; With = 4}
+	{IgnoreIfNotExisting = true; Action = AddBase; AddBaseTo = "<../../../workshop/content/799600/3023201707/large_impulse_drive/large_impulse_drive.rules>/Part/Components"; BaseToAdd = &<starwars/large_impulse_drive_ai.rules>}
+
 	//------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Tiered parts https://steamcommunity.com/sharedfiles/filedetails/?id=2888343841
 

--- a/more_cannons/2_381mm.rules
+++ b/more_cannons/2_381mm.rules
@@ -1,0 +1,227 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour, PartCrewMinusFive, PartCrewMinusSix]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, NeedsCrewMinusFour, NeedsCrewMinusFive, PartCrewMinusSix]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 6
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 5
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 4
+	MinBuffValue = 4
+}
+PartCrewMinusFour
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFour]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFive
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 5
+	MinBuffValue = 5
+}
+PartCrewMinusFive
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFive]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusSix
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 6
+}

--- a/more_cannons/2_420mm.rules
+++ b/more_cannons/2_420mm.rules
@@ -1,0 +1,334 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour, PartCrewMinusFive, PartCrewMinusSix, PartCrewMinusSeven, PartCrewMinusEight]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, NeedsCrewMinusFour, NeedsCrewMinusFive, NeedsCrewMinusSix, NeedsCrewMinusSeven, PartCrewMinusEight]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 8
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+		[0.5, 5.1]
+		[5.5, 5.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation7
+		CrewLocation8
+	]
+}
+
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 7
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+		[0.5, 5.1]
+		[5.5, 5.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 6
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+		[0.5, 5.1]
+		[5.5, 5.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 5
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+		[0.5, 5.1]
+		[5.5, 5.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 4
+	MinBuffValue = 4
+}
+PartCrewMinusFour
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFour]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+		[0.5, 5.1]
+		[5.5, 5.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFive
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 5
+	MinBuffValue = 5
+}
+PartCrewMinusFive
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFive]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+		[0.5, 5.1]
+		[5.5, 5.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusSix
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 6
+	MinBuffValue = 6
+}
+PartCrewMinusSix
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusSix]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+		[0.5, 5.1]
+		[5.5, 5.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusSeven
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 7
+	MinBuffValue = 7
+}
+PartCrewMinusSeven
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusSeven]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+		[0.5, 5.1]
+		[5.5, 5.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusEight
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 8
+}

--- a/more_cannons/2_420mm_b.rules
+++ b/more_cannons/2_420mm_b.rules
@@ -1,0 +1,334 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour, PartCrewMinusFive, PartCrewMinusSix, PartCrewMinusSeven, PartCrewMinusEight]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, NeedsCrewMinusFour, NeedsCrewMinusFive, NeedsCrewMinusSix, NeedsCrewMinusSeven, PartCrewMinusEight]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 8
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+		[0.5, 5.1]
+		[5.5, 5.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation7
+		CrewLocation8
+	]
+}
+
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 7
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+		[0.5, 5.1]
+		[5.5, 5.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 6
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+		[0.5, 5.1]
+		[5.5, 5.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 5
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+		[0.5, 5.1]
+		[5.5, 5.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 4
+	MinBuffValue = 4
+}
+PartCrewMinusFour
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFour]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+		[0.5, 5.1]
+		[5.5, 5.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFive
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 5
+	MinBuffValue = 5
+}
+PartCrewMinusFive
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFive]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+		[0.5, 5.1]
+		[5.5, 5.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusSix
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 6
+	MinBuffValue = 6
+}
+PartCrewMinusSix
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusSix]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+		[0.5, 5.1]
+		[5.5, 5.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusSeven
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 7
+	MinBuffValue = 7
+}
+PartCrewMinusSeven
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusSeven]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.7+89/64, 0.7+110/64]
+		[1.3+166/64, 0.7+110/64]
+		[0.5+67/64, 1.35+189/64]
+		[1.5+189/64, 1.35+189/64]
+		[0.6, 0.6]
+		[5.4, 0.6]
+		[0.5, 5.1]
+		[5.5, 5.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusEight
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 8
+}

--- a/more_cannons/2_510mm.rules
+++ b/more_cannons/2_510mm.rules
@@ -1,0 +1,334 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour, PartCrewMinusFive, PartCrewMinusSix, PartCrewMinusSeven, PartCrewMinusEight]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, NeedsCrewMinusFour, NeedsCrewMinusFive, NeedsCrewMinusSix, NeedsCrewMinusSeven, PartCrewMinusEight]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 8
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[2*89/64, 2*110/64-0.1]
+		[2*166/64, 2*110/64-0.1]
+		[2*67/64, 0.4+2*189/64]
+		[2*189/64, 0.4+2*189/64]
+		[0.8, 0.8]
+		[7.2, 0.8]
+		[0.6, 7.45]
+		[7.4, 7.45]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation7
+		CrewLocation8
+	]
+}
+
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 7
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2*89/64, 2*110/64-0.1]
+		[2*166/64, 2*110/64-0.1]
+		[2*67/64, 0.4+2*189/64]
+		[2*189/64, 0.4+2*189/64]
+		[0.8, 0.8]
+		[7.2, 0.8]
+		[0.6, 7.45]
+		[7.4, 7.45]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 6
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2*89/64, 2*110/64-0.1]
+		[2*166/64, 2*110/64-0.1]
+		[2*67/64, 0.4+2*189/64]
+		[2*189/64, 0.4+2*189/64]
+		[0.8, 0.8]
+		[7.2, 0.8]
+		[0.6, 7.45]
+		[7.4, 7.45]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 5
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2*89/64, 2*110/64-0.1]
+		[2*166/64, 2*110/64-0.1]
+		[2*67/64, 0.4+2*189/64]
+		[2*189/64, 0.4+2*189/64]
+		[0.8, 0.8]
+		[7.2, 0.8]
+		[0.6, 7.45]
+		[7.4, 7.45]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 4
+	MinBuffValue = 4
+}
+PartCrewMinusFour
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFour]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2*89/64, 2*110/64-0.1]
+		[2*166/64, 2*110/64-0.1]
+		[2*67/64, 0.4+2*189/64]
+		[2*189/64, 0.4+2*189/64]
+		[0.8, 0.8]
+		[7.2, 0.8]
+		[0.6, 7.45]
+		[7.4, 7.45]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFive
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 5
+	MinBuffValue = 5
+}
+PartCrewMinusFive
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFive]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2*89/64, 2*110/64-0.1]
+		[2*166/64, 2*110/64-0.1]
+		[2*67/64, 0.4+2*189/64]
+		[2*189/64, 0.4+2*189/64]
+		[0.8, 0.8]
+		[7.2, 0.8]
+		[0.6, 7.45]
+		[7.4, 7.45]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusSix
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 6
+	MinBuffValue = 6
+}
+PartCrewMinusSix
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusSix]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2*89/64, 2*110/64-0.1]
+		[2*166/64, 2*110/64-0.1]
+		[2*67/64, 0.4+2*189/64]
+		[2*189/64, 0.4+2*189/64]
+		[0.8, 0.8]
+		[7.2, 0.8]
+		[0.6, 7.45]
+		[7.4, 7.45]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusSeven
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 7
+	MinBuffValue = 7
+}
+PartCrewMinusSeven
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusSeven]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2*89/64, 2*110/64-0.1]
+		[2*166/64, 2*110/64-0.1]
+		[2*67/64, 0.4+2*189/64]
+		[2*189/64, 0.4+2*189/64]
+		[0.8, 0.8]
+		[7.2, 0.8]
+		[0.6, 7.45]
+		[7.4, 7.45]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusEight
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 8
+}

--- a/more_cannons/2_800mm.rules
+++ b/more_cannons/2_800mm.rules
@@ -1,0 +1,1254 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour, PartCrewMinusFive, PartCrewMinusSix, PartCrewMinusSeven, PartCrewMinusEight, PartCrewMinusNine, PartCrewMinusTen, PartCrewMinusEleven, PartCrewMinusTwelve, PartCrewMinusThirteen, PartCrewMinusFourteen, PartCrewMinusFifteen, PartCrewMinusSixteen, PartCrewMinusSeventeen, PartCrewMinusEighteen, PartCrewMinusNineteen, PartCrewMinusTwenty]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, NeedsCrewMinusFour, NeedsCrewMinusFive, NeedsCrewMinusSix, NeedsCrewMinusSeven, NeedsCrewMinusEight, NeedsCrewMinusNine, NeedsCrewMinusTen, NeedsCrewMinusEleven, NeedsCrewMinusTwelve, NeedsCrewMinusThirteen, NeedsCrewMinusFourteen, NeedsCrewMinusFifteen, NeedsCrewMinusSixteen, NeedsCrewMinusSeventeen, NeedsCrewMinusEighteen, NeedsCrewMinusNineteen, PartCrewMinusTwenty]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 20
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 19
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 18
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 17
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 4
+	MinBuffValue = 4
+}
+PartCrewMinusFour
+{
+	Type = PartCrew
+	Crew = 16
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusFive
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 5
+	MinBuffValue = 5
+}
+PartCrewMinusFive
+{
+	Type = PartCrew
+	Crew = 15
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusSix
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 6
+	MinBuffValue = 6
+}
+PartCrewMinusSix
+{
+	Type = PartCrew
+	Crew = 14
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusSeven
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 7
+	MinBuffValue = 7
+}
+PartCrewMinusSeven
+{
+	Type = PartCrew
+	Crew = 13
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusEight
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 8
+	MinBuffValue = 8
+}
+PartCrewMinusEight
+{
+	Type = PartCrew
+	Crew = 12
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusNine
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 9
+	MinBuffValue = 9
+}
+PartCrewMinusNine
+{
+	Type = PartCrew
+	Crew = 11
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusTen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 10
+	MinBuffValue = 10
+}
+PartCrewMinusTen
+{
+	Type = PartCrew
+	Crew = 10
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusEleven
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 11
+	MinBuffValue = 11
+}
+PartCrewMinusEleven
+{
+	Type = PartCrew
+	Crew = 9
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusTwelve
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 12
+	MinBuffValue = 12
+}
+PartCrewMinusTwelve
+{
+	Type = PartCrew
+	Crew = 8
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusThirteen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 13
+	MinBuffValue = 13
+}
+PartCrewMinusThirteen
+{
+	Type = PartCrew
+	Crew = 7
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusFourteen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 14
+	MinBuffValue = 14
+}
+PartCrewMinusFourteen
+{
+	Type = PartCrew
+	Crew = 6
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusFifteen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 15
+	MinBuffValue = 15
+}
+PartCrewMinusFifteen
+{
+	Type = PartCrew
+	Crew = 5
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusSixteen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 16
+	MinBuffValue = 16
+}
+PartCrewMinusSixteen
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusSeventeen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 17
+	MinBuffValue = 17
+}
+PartCrewMinusSeventeen
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusEighteen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 18
+	MinBuffValue = 18
+}
+PartCrewMinusEighteen
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusNineteen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 19
+	MinBuffValue = 19
+}
+PartCrewMinusNineteen
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+PartCrewMinusTwenty
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 20
+}

--- a/more_cannons/3_152mm.rules
+++ b/more_cannons/3_152mm.rules
@@ -1,0 +1,139 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[89/64, 110/64]
+		[166/64, 110/64]
+		[67/64, 189/64]
+		[189/64, 189/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[89/64, 110/64]
+		[166/64, 110/64]
+		[67/64, 189/64]
+		[189/64, 189/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[89/64, 110/64]
+		[166/64, 110/64]
+		[67/64, 189/64]
+		[189/64, 189/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[89/64, 110/64]
+		[166/64, 110/64]
+		[67/64, 189/64]
+		[189/64, 189/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 4
+}

--- a/more_cannons/3_460mm.rules
+++ b/more_cannons/3_460mm.rules
@@ -1,0 +1,334 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour, PartCrewMinusFive, PartCrewMinusSix, PartCrewMinusSeven, PartCrewMinusEight]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, NeedsCrewMinusFour, NeedsCrewMinusFive, NeedsCrewMinusSix, NeedsCrewMinusSeven, PartCrewMinusEight]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 8
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[2*89/64, 2*110/64-0.1]
+		[2*166/64, 2*110/64-0.1]
+		[2*67/64, 0.4+2*189/64]
+		[2*189/64, 0.4+2*189/64]
+		[0.8, 0.8]
+		[7.2, 0.8]
+		[0.6, 7.45]
+		[7.4, 7.45]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation7
+		CrewLocation8
+	]
+}
+
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 7
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2*89/64, 2*110/64-0.1]
+		[2*166/64, 2*110/64-0.1]
+		[2*67/64, 0.4+2*189/64]
+		[2*189/64, 0.4+2*189/64]
+		[0.8, 0.8]
+		[7.2, 0.8]
+		[0.6, 7.45]
+		[7.4, 7.45]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 6
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2*89/64, 2*110/64-0.1]
+		[2*166/64, 2*110/64-0.1]
+		[2*67/64, 0.4+2*189/64]
+		[2*189/64, 0.4+2*189/64]
+		[0.8, 0.8]
+		[7.2, 0.8]
+		[0.6, 7.45]
+		[7.4, 7.45]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 5
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2*89/64, 2*110/64-0.1]
+		[2*166/64, 2*110/64-0.1]
+		[2*67/64, 0.4+2*189/64]
+		[2*189/64, 0.4+2*189/64]
+		[0.8, 0.8]
+		[7.2, 0.8]
+		[0.6, 7.45]
+		[7.4, 7.45]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 4
+	MinBuffValue = 4
+}
+PartCrewMinusFour
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFour]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2*89/64, 2*110/64-0.1]
+		[2*166/64, 2*110/64-0.1]
+		[2*67/64, 0.4+2*189/64]
+		[2*189/64, 0.4+2*189/64]
+		[0.8, 0.8]
+		[7.2, 0.8]
+		[0.6, 7.45]
+		[7.4, 7.45]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFive
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 5
+	MinBuffValue = 5
+}
+PartCrewMinusFive
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFive]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2*89/64, 2*110/64-0.1]
+		[2*166/64, 2*110/64-0.1]
+		[2*67/64, 0.4+2*189/64]
+		[2*189/64, 0.4+2*189/64]
+		[0.8, 0.8]
+		[7.2, 0.8]
+		[0.6, 7.45]
+		[7.4, 7.45]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusSix
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 6
+	MinBuffValue = 6
+}
+PartCrewMinusSix
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusSix]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2*89/64, 2*110/64-0.1]
+		[2*166/64, 2*110/64-0.1]
+		[2*67/64, 0.4+2*189/64]
+		[2*189/64, 0.4+2*189/64]
+		[0.8, 0.8]
+		[7.2, 0.8]
+		[0.6, 7.45]
+		[7.4, 7.45]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusSeven
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 7
+	MinBuffValue = 7
+}
+PartCrewMinusSeven
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusSeven]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2*89/64, 2*110/64-0.1]
+		[2*166/64, 2*110/64-0.1]
+		[2*67/64, 0.4+2*189/64]
+		[2*189/64, 0.4+2*189/64]
+		[0.8, 0.8]
+		[7.2, 0.8]
+		[0.6, 7.45]
+		[7.4, 7.45]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusEight
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 8
+}

--- a/more_cannons/3_800mm.rules
+++ b/more_cannons/3_800mm.rules
@@ -1,0 +1,1254 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour, PartCrewMinusFive, PartCrewMinusSix, PartCrewMinusSeven, PartCrewMinusEight, PartCrewMinusNine, PartCrewMinusTen, PartCrewMinusEleven, PartCrewMinusTwelve, PartCrewMinusThirteen, PartCrewMinusFourteen, PartCrewMinusFifteen, PartCrewMinusSixteen, PartCrewMinusSeventeen, PartCrewMinusEighteen, PartCrewMinusNineteen, PartCrewMinusTwenty]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, NeedsCrewMinusFour, NeedsCrewMinusFive, NeedsCrewMinusSix, NeedsCrewMinusSeven, NeedsCrewMinusEight, NeedsCrewMinusNine, NeedsCrewMinusTen, NeedsCrewMinusEleven, NeedsCrewMinusTwelve, NeedsCrewMinusThirteen, NeedsCrewMinusFourteen, NeedsCrewMinusFifteen, NeedsCrewMinusSixteen, NeedsCrewMinusSeventeen, NeedsCrewMinusEighteen, NeedsCrewMinusNineteen, PartCrewMinusTwenty]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 20
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 19
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 18
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 17
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 4
+	MinBuffValue = 4
+}
+PartCrewMinusFour
+{
+	Type = PartCrew
+	Crew = 16
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusFive
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 5
+	MinBuffValue = 5
+}
+PartCrewMinusFive
+{
+	Type = PartCrew
+	Crew = 15
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusSix
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 6
+	MinBuffValue = 6
+}
+PartCrewMinusSix
+{
+	Type = PartCrew
+	Crew = 14
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusSeven
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 7
+	MinBuffValue = 7
+}
+PartCrewMinusSeven
+{
+	Type = PartCrew
+	Crew = 13
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusEight
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 8
+	MinBuffValue = 8
+}
+PartCrewMinusEight
+{
+	Type = PartCrew
+	Crew = 12
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusNine
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 9
+	MinBuffValue = 9
+}
+PartCrewMinusNine
+{
+	Type = PartCrew
+	Crew = 11
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusTen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 10
+	MinBuffValue = 10
+}
+PartCrewMinusTen
+{
+	Type = PartCrew
+	Crew = 10
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusEleven
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 11
+	MinBuffValue = 11
+}
+PartCrewMinusEleven
+{
+	Type = PartCrew
+	Crew = 9
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusTwelve
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 12
+	MinBuffValue = 12
+}
+PartCrewMinusTwelve
+{
+	Type = PartCrew
+	Crew = 8
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusThirteen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 13
+	MinBuffValue = 13
+}
+PartCrewMinusThirteen
+{
+	Type = PartCrew
+	Crew = 7
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusFourteen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 14
+	MinBuffValue = 14
+}
+PartCrewMinusFourteen
+{
+	Type = PartCrew
+	Crew = 6
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusFifteen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 15
+	MinBuffValue = 15
+}
+PartCrewMinusFifteen
+{
+	Type = PartCrew
+	Crew = 5
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusSixteen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 16
+	MinBuffValue = 16
+}
+PartCrewMinusSixteen
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusSeventeen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 17
+	MinBuffValue = 17
+}
+PartCrewMinusSeventeen
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusEighteen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 18
+	MinBuffValue = 18
+}
+PartCrewMinusEighteen
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+NeedsCrewMinusNineteen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 19
+	MinBuffValue = 19
+}
+PartCrewMinusNineteen
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[4*89/64, 3.8*110/64]
+		[4*166/64, 3.8*110/64]
+		[4*67/64, 4.24*189/64]
+		[4*189/64, 4.24*189/64]
+		[1.3, 1.3]
+		[14.7, 1.3]
+		[1.1, 13.2]
+		[14.9, 13.2]
+		[0.95, 14.8]
+		[15.05, 14.8]
+		[4*89/64+0.6, 3.8*110/64]
+		[4*166/64-0.6, 3.8*110/64]
+		[4*67/64+0.6, 4.2*189/64-0.3]
+		[4*189/64-0.6, 4.2*189/64-0.3]
+		[1.3+0.7, 1.3-0.4]
+		[14.7-0.7, 1.3-0.4]
+		[1.3-0.4, 1.3+0.7]
+		[14.7+0.4, 1.3+0.7]
+		[4*89/64-0.6, 3.8*110/64]
+		[4*166/64+0.6, 3.8*110/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+		CrewLocation13
+		CrewLocation14
+		CrewLocation15
+		CrewLocation16
+		CrewLocation17
+		CrewLocation18
+		CrewLocation19
+		CrewLocation20
+	]
+}
+
+PartCrewMinusTwenty
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 20
+}

--- a/more_cannons/4_130mm.rules
+++ b/more_cannons/4_130mm.rules
@@ -1,0 +1,139 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[89/64, 110/64]
+		[166/64, 110/64]
+		[67/64, 189/64]
+		[189/64, 189/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[89/64, 110/64]
+		[166/64, 110/64]
+		[67/64, 189/64]
+		[189/64, 189/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[89/64, 110/64]
+		[166/64, 110/64]
+		[67/64, 189/64]
+		[189/64, 189/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[89/64, 110/64]
+		[166/64, 110/64]
+		[67/64, 189/64]
+		[189/64, 189/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 4
+}

--- a/more_cannons/4_431mm.rules
+++ b/more_cannons/4_431mm.rules
@@ -1,0 +1,441 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour, PartCrewMinusFive, PartCrewMinusSix, PartCrewMinusSeven, PartCrewMinusEight, PartCrewMinusNine, PartCrewMinusTen]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, NeedsCrewMinusFour, NeedsCrewMinusFive, NeedsCrewMinusSix, NeedsCrewMinusSeven, NeedsCrewMinusEight, NeedsCrewMinusNine, PartCrewMinusTen]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 10
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 9
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 8
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 7
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 4
+	MinBuffValue = 4
+}
+PartCrewMinusFour
+{
+	Type = PartCrew
+	Crew = 6
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFour]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusFive
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 5
+	MinBuffValue = 5
+}
+PartCrewMinusFive
+{
+	Type = PartCrew
+	Crew = 5
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFive]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusSix
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 6
+	MinBuffValue = 6
+}
+PartCrewMinusSix
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusSix]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusSeven
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 7
+	MinBuffValue = 7
+}
+PartCrewMinusSeven
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusSeven]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusEight
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 8
+	MinBuffValue = 8
+}
+PartCrewMinusEight
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusEight]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusNine
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 9
+	MinBuffValue = 9
+}
+PartCrewMinusNine
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNine]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+PartCrewMinusTen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 10
+}

--- a/more_cannons/6_406mm.rules
+++ b/more_cannons/6_406mm.rules
@@ -1,0 +1,441 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour, PartCrewMinusFive, PartCrewMinusSix, PartCrewMinusSeven, PartCrewMinusEight, PartCrewMinusNine, PartCrewMinusTen]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, NeedsCrewMinusFour, NeedsCrewMinusFive, NeedsCrewMinusSix, NeedsCrewMinusSeven, NeedsCrewMinusEight, NeedsCrewMinusNine, PartCrewMinusTen]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 10
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 9
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 8
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 7
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 4
+	MinBuffValue = 4
+}
+PartCrewMinusFour
+{
+	Type = PartCrew
+	Crew = 6
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFour]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusFive
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 5
+	MinBuffValue = 5
+}
+PartCrewMinusFive
+{
+	Type = PartCrew
+	Crew = 5
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFive]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusSix
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 6
+	MinBuffValue = 6
+}
+PartCrewMinusSix
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusSix]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusSeven
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 7
+	MinBuffValue = 7
+}
+PartCrewMinusSeven
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusSeven]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusEight
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 8
+	MinBuffValue = 8
+}
+PartCrewMinusEight
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusEight]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusNine
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 9
+	MinBuffValue = 9
+}
+PartCrewMinusNine
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNine]
+	HighPriorityPrerequisites = [AmmoPrereq]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.5*89/64, 2.35*110/64]
+		[2.5*166/64, 2.35*110/64]
+		[2.5*67/64, 2.55*189/64]
+		[2.5*189/64, 2.55*189/64]
+		[0.9, 0.9]
+		[9.1, 0.9]
+		[0.7, 7.8]
+		[9.3, 7.8]
+		[0.6, 8.9]
+		[9.4, 8.9]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+PartCrewMinusTen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 10
+}

--- a/starwars/DSLaser_core.rules
+++ b/starwars/DSLaser_core.rules
@@ -1,0 +1,139 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[.921875, 3.15]
+		[.921875, 3.85]
+		[5.078125, 3.15]
+		[5.078125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+				[.921875, 3.15]
+				[.921875, 3.85]
+				[5.078125, 3.15]
+				[5.078125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+				[.921875, 3.15]
+				[.921875, 3.85]
+				[5.078125, 3.15]
+				[5.078125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+				[.921875, 3.15]
+				[.921875, 3.85]
+				[5.078125, 3.15]
+				[5.078125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 4
+}

--- a/starwars/WarRoom.rules
+++ b/starwars/WarRoom.rules
@@ -1,0 +1,277 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [
+		PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, 
+		PartCrewMinusFour, PartCrewMinusFive, PartCrewMinusSix, PartCrewMinusSeven, PartCrewMinusEight
+	]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [
+		NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, NeedsCrewMinusFour, 
+		NeedsCrewMinusFive, NeedsCrewMinusSix, NeedsCrewMinusSeven, PartCrewMinusEight
+	]
+	Mode = Any
+	Invert = True
+}
+
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 8
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[3, 2.27]
+		[1.75, 3.5]
+		[4.25, 3.5]
+		[3, 4.72]
+		[1.5, 2]
+		[4.5, 2]
+		[2, 5.5]
+		[3.99, 5.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 7
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 2.27]
+		[1.75, 3.5]
+		[4.25, 3.5]
+		[3, 4.72]
+		[1.5, 2]
+		[4.5, 2]
+		[2, 5.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+	]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 6
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 2.27]
+		[1.75, 3.5]
+		[4.25, 3.5]
+		[3, 4.72]
+		[1.5, 2]
+		[4.5, 2]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 5
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 2.27]
+		[1.75, 3.5]
+		[4.25, 3.5]
+		[3, 4.72]
+		[1.5, 2]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+	]
+}
+
+NeedsCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 4
+	MinBuffValue = 4
+}
+PartCrewMinusFour
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFour]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 2.27]
+		[1.75, 3.5]
+		[4.25, 3.5]
+		[3, 4.72]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusFive
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 5
+	MinBuffValue = 5
+}
+
+PartCrewMinusFive
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFive]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 2.27]
+		[1.75, 3.5]
+		[4.25, 3.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+	]
+}
+
+NeedsCrewMinusSix
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 6
+	MinBuffValue = 6
+}
+
+PartCrewMinusSix
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusSix]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 2.27]
+		[1.75, 3.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusSeven
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 7
+	MinBuffValue = 7
+}
+PartCrewMinusSeven
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusSeven]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 2.27]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+	]
+}
+
+PartCrewMinusEight
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 8
+}

--- a/starwars/axial_superlaser.rules
+++ b/starwars/axial_superlaser.rules
@@ -1,0 +1,139 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[2.921875, 3.15]
+		[2.921875, 3.85]
+		[9.078125, 3.15]
+		[9.078125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.921875, 3.15]
+		[2.921875, 3.85]
+		[9.078125, 3.15]
+		[9.078125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.921875, 3.15]
+		[2.921875, 3.85]
+		[9.078125, 3.15]
+		[9.078125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2.921875, 3.15]
+		[2.921875, 3.85]
+		[9.078125, 3.15]
+		[9.078125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 4
+}

--- a/starwars/bridge.rules
+++ b/starwars/bridge.rules
@@ -1,0 +1,492 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [
+		PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, 
+		PartCrewMinusFour, PartCrewMinusFive, PartCrewMinusSix, PartCrewMinusSeven, 
+		PartCrewMinusEight, PartCrewMinusNine, PartCrewMinusTen, PartCrewMinusEleven, 
+		PartCrewMinusTwelve
+	]
+	Mode = Any
+}
+IsOperational
+{
+	Type = MultiToggle
+	Toggles = [PowerToggle, BatteryStorage, PartCrew]
+	Mode = All
+}
+Indicators
+{
+	Type = IndicatorSprites
+	Location = [3, 3.5]
+	Indicators
+	[
+		// Turned off.
+		{
+			Toggle = PowerToggle
+			AtlasSprite
+			{
+				File = &/INDICATORS/PowerOff
+				Size = [2, 2]
+			}
+		}
+		// Out of power.
+		{
+			Toggle = BatteryStorage
+			AtlasSprite
+			{
+				File = &/INDICATORS/NoPower
+				Size = [3, 3]
+			}
+		}
+		// No AI crew (replacing manual crew indicators)
+		{
+			Toggle = PartCrew
+			Invert = true  // Only shows if AI crew is missing
+			AtlasSprite
+			{
+				File = &/INDICATORS/NoCrew
+				Offset = [0, -2.6]
+				Size = [5, 5]
+			}
+		}
+	]
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [
+		NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, NeedsCrewMinusFour, 
+		NeedsCrewMinusFive, NeedsCrewMinusSix, NeedsCrewMinusSeven, NeedsCrewMinusEight, 
+		NeedsCrewMinusNine, NeedsCrewMinusTen, NeedsCrewMinusEleven, PartCrewMinusTwelve
+	]
+	Mode = Any
+	Invert = True
+}
+
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 12
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[3, 0.75]
+		[2.08, 2.34]
+		[2.08, 3.02]
+		[2.08, 3.67]
+		[2.08, 4.34]
+		[2.08, 5]
+		[1.39, 4.05]
+		[1.39, 4.7]
+		[1.39, 5.39]
+		[3.92, 2.34]
+		[3.92, 3.02]
+		[3.92, 3.67]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+		CrewLocation12
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 11
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 0.75]
+		[2.08, 2.34]
+		[2.08, 3.02]
+		[2.08, 3.67]
+		[2.08, 4.34]
+		[2.08, 5]
+		[1.39, 4.05]
+		[1.39, 4.7]
+		[1.39, 5.39]
+		[3.92, 2.34]
+		[3.92, 3.02]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+		CrewLocation11
+	]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 10
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 0.75]
+		[2.08, 2.34]
+		[2.08, 3.02]
+		[2.08, 3.67]
+		[2.08, 4.34]
+		[2.08, 5]
+		[1.39, 4.05]
+		[1.39, 4.7]
+		[3.92, 2.34]
+		[3.92, 3.02]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+		CrewLocation10
+	]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 9
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 0.75]
+		[2.08, 2.34]
+		[2.08, 3.02]
+		[2.08, 3.67]
+		[2.08, 4.34]
+		[2.08, 5]
+		[1.39, 4.05]
+		[3.92, 2.34]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+		CrewLocation9
+	]
+}
+
+NeedsCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 4
+	MinBuffValue = 4
+}
+PartCrewMinusFour
+{
+	Type = PartCrew
+	Crew = 8
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFour]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 0.75]
+		[2.08, 2.34]
+		[2.08, 3.02]
+		[2.08, 3.67]
+		[2.08, 4.34]
+		[2.08, 5]
+		[1.39, 4.05]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+		CrewLocation8
+	]
+}
+
+NeedsCrewMinusFive
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 5
+	MinBuffValue = 5
+}
+PartCrewMinusFive
+{
+	Type = PartCrew
+	Crew = 7
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFive]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 0.75]
+		[2.08, 2.34]
+		[2.08, 3.02]
+		[2.08, 3.67]
+		[2.08, 4.34]
+		[2.08, 5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+		CrewLocation7
+	]
+}
+
+NeedsCrewMinusSix
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 6
+	MinBuffValue = 6
+}
+PartCrewMinusSix
+{
+	Type = PartCrew
+	Crew = 6
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusSix]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 0.75]
+		[2.08, 2.34]
+		[2.08, 3.02]
+		[2.08, 3.67]
+		[2.08, 4.34]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+}
+
+NeedsCrewMinusSeven
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 7
+	MinBuffValue = 7
+}
+PartCrewMinusSeven
+{
+	Type = PartCrew
+	Crew = 5
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusSeven]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 0.75]
+		[2.08, 2.34]
+		[2.08, 3.02]
+		[2.08, 3.67]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+	]
+}
+
+NeedsCrewMinusEight
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 8
+	MinBuffValue = 8
+}
+PartCrewMinusEight
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusEight]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 0.75]
+		[2.08, 2.34]
+		[2.08, 3.02]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusNine
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 9
+	MinBuffValue = 9
+}
+PartCrewMinusNine
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNine]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 0.75]
+		[2.08, 2.34]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+	]
+}
+
+NeedsCrewMinusTen
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 10
+	MinBuffValue = 10
+}
+PartCrewMinusTen
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTen]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 0.75]
+		[2.08, 2.34]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusEleven
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 11
+	MinBuffValue = 11
+}
+PartCrewMinusEleven
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTen]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3, 0.75]
+		[2.08, 2.34]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+PartCrewMinusTwelve
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 12
+}

--- a/starwars/cis_turbolaser_switchable.rules
+++ b/starwars/cis_turbolaser_switchable.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[1.55, 1.6]
+		[2.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[1.55, 1.6]
+		[2.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/deathstar_superlaser.rules
+++ b/starwars/deathstar_superlaser.rules
@@ -1,0 +1,139 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[.921875, 3.15]
+		[.921875, 3.85]
+		[5.078125, 3.15]
+		[5.078125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.921875, 3.15]
+		[.921875, 3.85]
+		[5.078125, 3.15]
+		[5.078125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.921875, 3.15]
+		[.921875, 3.85]
+		[5.078125, 3.15]
+		[5.078125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.921875, 3.15]
+		[.921875, 3.85]
+		[5.078125, 3.15]
+		[5.078125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 4
+}

--- a/starwars/deathstar_superlaser_sect2L.rules
+++ b/starwars/deathstar_superlaser_sect2L.rules
@@ -1,0 +1,139 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[.45, 1.5]
+		[.5, 3.5]
+		[.5, 4.5]
+		[.45, 6.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.45, 1.5]
+		[.5, 3.5]
+		[.5, 4.5]
+		[.45, 6.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.45, 1.5]
+		[.5, 3.5]
+		[.5, 4.5]
+		[.45, 6.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.45, 1.5]
+		[.5, 3.5]
+		[.5, 4.5]
+		[.45, 6.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 4
+}

--- a/starwars/deathstar_superlaser_sect2R.rules
+++ b/starwars/deathstar_superlaser_sect2R.rules
@@ -1,0 +1,139 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[.55, 1.5]
+		[.5, 3.5]
+		[.5, 4.5]
+		[.55, 6.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.55, 1.5]
+		[.5, 3.5]
+		[.5, 4.5]
+		[.55, 6.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.55, 1.5]
+		[.5, 3.5]
+		[.5, 4.5]
+		[.55, 6.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.55, 1.5]
+		[.5, 3.5]
+		[.5, 4.5]
+		[.55, 6.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 4
+}

--- a/starwars/droid_turret.rules
+++ b/starwars/droid_turret.rules
@@ -1,0 +1,36 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusOne]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[.5, 0.6875]
+	]
+	CrewLocations
+	[
+		CrewLocation
+	]
+}
+
+PartCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+}

--- a/starwars/engineering_bay_ai.rules
+++ b/starwars/engineering_bay_ai.rules
@@ -1,0 +1,139 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Thruster_Supply
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[40/64, 40/64]
+		[216/64, 40/64]
+		[40/64, 216/64]
+		[216/64, 216/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Thruster_Supply
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[40/64, 40/64]
+		[216/64, 40/64]
+		[40/64, 216/64]
+		[216/64, 216/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Thruster_Supply
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[40/64, 40/64]
+		[216/64, 40/64]
+		[40/64, 216/64]
+		[216/64, 216/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Thruster_Supply
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[40/64, 40/64]
+		[216/64, 40/64]
+		[40/64, 216/64]
+		[216/64, 216/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 4
+}

--- a/starwars/falcon_laser_cannon.rules
+++ b/starwars/falcon_laser_cannon.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[0.55, 0.5]
+		[1.45, 0.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.55, 0.5]
+		[1.45, 0.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/fixedheavylaser.rules
+++ b/starwars/fixedheavylaser.rules
@@ -1,0 +1,36 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusOne]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[1, 4.5]
+	]
+	CrewLocations
+	[
+		CrewLocation
+	]
+}
+
+PartCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+}

--- a/starwars/heavy_artillery_turbolaser_SPHA_T.rules
+++ b/starwars/heavy_artillery_turbolaser_SPHA_T.rules
@@ -1,0 +1,139 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[.421875, 3.15]
+		[.421875, 3.85]
+		[3.578125, 3.15]
+		[3.578125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.421875, 3.15]
+		[.421875, 3.85]
+		[3.578125, 3.15]
+		[3.578125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.421875, 3.15]
+		[.421875, 3.85]
+		[3.578125, 3.15]
+		[3.578125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.421875, 3.15]
+		[.421875, 3.85]
+		[3.578125, 3.15]
+		[3.578125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 4
+}

--- a/starwars/heavy_ion_cannon_switchable.rules
+++ b/starwars/heavy_ion_cannon_switchable.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[1.55, 1.6]
+		[2.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[1.55, 1.6]
+		[2.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/heavy_turbolaser_switchable.rules
+++ b/starwars/heavy_turbolaser_switchable.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[1.55, 1.6]
+		[2.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[1.55, 1.6]
+		[2.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/imperial_turbolaser_switchable.rules
+++ b/starwars/imperial_turbolaser_switchable.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[1.55, 1.6]
+		[2.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[1.55, 1.6]
+		[2.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/large_impulse_drive_ai.rules
+++ b/starwars/large_impulse_drive_ai.rules
@@ -1,0 +1,139 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Thruster_Supply
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[0.5, 0.5]
+		[0.5, 5.5]
+		[5.5, 0.5]
+		[5.5, 5.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Thruster_Supply
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.5, 0.5]
+		[0.5, 5.5]
+		[5.5, 0.5]
+		[5.5, 5.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Thruster_Supply
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.5, 0.5]
+		[0.5, 5.5]
+		[5.5, 0.5]
+		[5.5, 5.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Thruster_Supply
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.5, 0.5]
+		[0.5, 5.5]
+		[5.5, 0.5]
+		[5.5, 5.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 4
+}

--- a/starwars/light_turbolaser_switchable.rules
+++ b/starwars/light_turbolaser_switchable.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[0.55, 0.6]
+		[1.45, 0.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.55, 0.6]
+		[1.45, 0.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/med_turbolaser_switchable.rules
+++ b/starwars/med_turbolaser_switchable.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[0.55, 0.5]
+		[1.45, 0.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.55, 0.5]
+		[1.45, 0.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/medium_ion_cannon.rules
+++ b/starwars/medium_ion_cannon.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[0.55, 0.5]
+		[1.45, 0.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.55, 0.5]
+		[1.45, 0.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/medium_triple_turbolaser.rules
+++ b/starwars/medium_triple_turbolaser.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[1.05, 1.1]
+		[1.95, 1.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[1.05, 1.1]
+		[1.95, 1.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/medium_turbolaser_quad03.rules
+++ b/starwars/medium_turbolaser_quad03.rules
@@ -1,0 +1,227 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour, PartCrewMinusFive, PartCrewMinusSix]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, NeedsCrewMinusFour, NeedsCrewMinusFive, PartCrewMinusSix]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 6
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[2, 6.5]
+		[3, 6.5]
+		[4, 6.5]
+		[5, 6.5]
+		[6, 6.5]
+		[3.5, 7.5]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 5
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2, 6.5]
+		[3, 6.5]
+		[4, 6.5]
+		[5, 6.5]
+		[6, 6.5]
+		[3.5, 7.5]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2, 6.5]
+		[3, 6.5]
+		[4, 6.5]
+		[5, 6.5]
+		[6, 6.5]
+		[3.5, 7.5]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2, 6.5]
+		[3, 6.5]
+		[4, 6.5]
+		[5, 6.5]
+		[6, 6.5]
+		[3.5, 7.5]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 4
+	MinBuffValue = 4
+}
+PartCrewMinusFour
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFour]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2, 6.5]
+		[3, 6.5]
+		[4, 6.5]
+		[5, 6.5]
+		[6, 6.5]
+		[3.5, 7.5]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFive
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 5
+	MinBuffValue = 5
+}
+PartCrewMinusFive
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFive]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2, 6.5]
+		[3, 6.5]
+		[4, 6.5]
+		[5, 6.5]
+		[6, 6.5]
+		[3.5, 7.5]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusSix
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 6
+}

--- a/starwars/medium_turbolaser_quad_switchable.rules
+++ b/starwars/medium_turbolaser_quad_switchable.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+        [1.55, 1.6]
+        [2.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+        [1.55, 1.6]
+        [2.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/mining_laser_huge.rules
+++ b/starwars/mining_laser_huge.rules
@@ -1,0 +1,101 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, PartCrewMinusThree]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[2, 1.81]
+		[1.36, 1.36]
+		[2.64, 1.36]
+	]
+	CrewLocations
+	[
+		CrewLocationMid
+		CrewLocationLeft
+		CrewLocationRight
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2, 1.81]
+		[1.36, 1.36]
+		[2.64, 1.36]
+	]
+	CrewLocations
+	[
+		CrewLocationMid
+		CrewLocationLeft
+		CrewLocationRight
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[2, 1.81]
+		[1.36, 1.36]
+		[2.64, 1.36]
+	]
+	CrewLocations
+	[
+		CrewLocationMid
+		CrewLocationLeft
+		CrewLocationRight
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 3
+}

--- a/starwars/missile_launcher.rules
+++ b/starwars/missile_launcher.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [MissilesPrereqToggleProxy]
+	CrewDestinations
+	[
+		[0.5, 4.44]
+		[1.5, 4.44]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [MissilesPrereqToggleProxy]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.5, 4.44]
+		[1.5, 4.44]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/missile_launcher_small.rules
+++ b/starwars/missile_launcher_small.rules
@@ -1,0 +1,36 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusOne]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [MissilesPrereqToggleProxy]
+	CrewDestinations
+	[
+		[0.5, 2]
+	]
+	CrewLocations
+	[
+		CrewLocation
+	]
+}
+
+PartCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+}

--- a/starwars/missile_launcher_small_tl_backup.rules
+++ b/starwars/missile_launcher_small_tl_backup.rules
@@ -1,0 +1,36 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusOne]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [MissilesPrereqToggleProxy]
+	CrewDestinations
+	[
+		[0.5, 2]
+	]
+	CrewLocations
+	[
+		CrewLocation
+	]
+}
+
+PartCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+}

--- a/starwars/octuple_barbette_turbolaser.rules
+++ b/starwars/octuple_barbette_turbolaser.rules
@@ -1,0 +1,227 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour, PartCrewMinusFive, PartCrewMinusSix]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, NeedsCrewMinusFour, NeedsCrewMinusFive, PartCrewMinusSix]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 6
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[165/64, 115/64]
+		[301/64, 94/64]
+		[119/64, 175/64]
+		[393/64, 175/64]
+		[2.5, 434/64]
+		[335/64, 445/64]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 5
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[165/64, 115/64]
+		[301/64, 94/64]
+		[119/64, 175/64]
+		[393/64, 175/64]
+		[2.5, 434/64]
+		[335/64, 445/64]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[165/64, 115/64]
+		[301/64, 94/64]
+		[119/64, 175/64]
+		[393/64, 175/64]
+		[2.5, 434/64]
+		[335/64, 445/64]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[165/64, 115/64]
+		[301/64, 94/64]
+		[119/64, 175/64]
+		[393/64, 175/64]
+		[2.5, 434/64]
+		[335/64, 445/64]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 4
+	MinBuffValue = 4
+}
+PartCrewMinusFour
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFour]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[165/64, 115/64]
+		[301/64, 94/64]
+		[119/64, 175/64]
+		[393/64, 175/64]
+		[2.5, 434/64]
+		[335/64, 445/64]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFive
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 5
+	MinBuffValue = 5
+}
+PartCrewMinusFive
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFive]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[165/64, 115/64]
+		[301/64, 94/64]
+		[119/64, 175/64]
+		[393/64, 175/64]
+		[2.5, 434/64]
+		[335/64, 445/64]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusSix
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 6
+}

--- a/starwars/orbital_autocannon.rules
+++ b/starwars/orbital_autocannon.rules
@@ -1,0 +1,139 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[4.421875, 3.15]
+		[4.421875, 3.85]
+		[7.578125, 3.15]
+		[7.578125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[4.421875, 3.15]
+		[4.421875, 3.85]
+		[7.578125, 3.15]
+		[7.578125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[4.421875, 3.15]
+		[4.421875, 3.85]
+		[7.578125, 3.15]
+		[7.578125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[4.421875, 3.15]
+		[4.421875, 3.85]
+		[7.578125, 3.15]
+		[7.578125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 4
+}

--- a/starwars/orbital_bombardment_particle_cannon.rules
+++ b/starwars/orbital_bombardment_particle_cannon.rules
@@ -1,0 +1,139 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[.421875, 3.15]
+		[.421875, 3.85]
+		[3.578125, 3.15]
+		[3.578125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.421875, 3.15]
+		[.421875, 3.85]
+		[3.578125, 3.15]
+		[3.578125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.421875, 3.15]
+		[.421875, 3.85]
+		[3.578125, 3.15]
+		[3.578125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.421875, 3.15]
+		[.421875, 3.85]
+		[3.578125, 3.15]
+		[3.578125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 4
+}

--- a/starwars/quad_barbette_turbolaser.rules
+++ b/starwars/quad_barbette_turbolaser.rules
@@ -1,0 +1,227 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour, PartCrewMinusFive, PartCrewMinusSix]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, NeedsCrewMinusFour, NeedsCrewMinusFive, PartCrewMinusSix]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 6
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[165/64, 115/64]
+		[301/64, 94/64]
+		[119/64, 175/64]
+		[393/64, 175/64]
+		[2.5, 434/64]
+		[335/64, 445/64]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 5
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[165/64, 115/64]
+		[301/64, 94/64]
+		[119/64, 175/64]
+		[393/64, 175/64]
+		[2.5, 434/64]
+		[335/64, 445/64]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[165/64, 115/64]
+		[301/64, 94/64]
+		[119/64, 175/64]
+		[393/64, 175/64]
+		[2.5, 434/64]
+		[335/64, 445/64]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[165/64, 115/64]
+		[301/64, 94/64]
+		[119/64, 175/64]
+		[393/64, 175/64]
+		[2.5, 434/64]
+		[335/64, 445/64]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 4
+	MinBuffValue = 4
+}
+PartCrewMinusFour
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFour]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[165/64, 115/64]
+		[301/64, 94/64]
+		[119/64, 175/64]
+		[393/64, 175/64]
+		[2.5, 434/64]
+		[335/64, 445/64]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFive
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 5
+	MinBuffValue = 5
+}
+PartCrewMinusFive
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFive]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[165/64, 115/64]
+		[301/64, 94/64]
+		[119/64, 175/64]
+		[393/64, 175/64]
+		[2.5, 434/64]
+		[335/64, 445/64]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusSix
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 6
+}

--- a/starwars/republic_turbolaser_switchable.rules
+++ b/starwars/republic_turbolaser_switchable.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[1.55, 1.6]
+		[2.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[1.55, 1.6]
+		[2.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/small_blasterlaser.rules
+++ b/starwars/small_blasterlaser.rules
@@ -1,0 +1,39 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne]
+	Mode = Any
+}
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusOne]
+	Mode = Any
+	Invert = True
+}
+CrewLocation
+{
+	Type = CrewLocation
+	Location = [.5, 1.75]
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[.5, 1.75]
+	]
+	CrewLocations
+	[
+		CrewLocation
+	]
+}
+PartCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+}

--- a/starwars/small_triple_turbolaser.rules
+++ b/starwars/small_triple_turbolaser.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[1.05, 1.1]
+		[1.95, 1.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[1.05, 1.1]
+		[1.95, 1.1]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/superheavy_composite_beam_turbolaser.rules
+++ b/starwars/superheavy_composite_beam_turbolaser.rules
@@ -1,0 +1,139 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[.421875, 3.15]
+		[.421875, 3.85]
+		[3.578125, 3.15]
+		[3.578125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.421875, 3.15]
+		[.421875, 3.85]
+		[3.578125, 3.15]
+		[3.578125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.421875, 3.15]
+		[.421875, 3.85]
+		[3.578125, 3.15]
+		[3.578125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[.421875, 3.15]
+		[.421875, 3.85]
+		[3.578125, 3.15]
+		[3.578125, 3.85]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 4
+}

--- a/starwars/swturret_A.rules
+++ b/starwars/swturret_A.rules
@@ -1,0 +1,36 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusOne]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[.5, 0.6875]
+	]
+	CrewLocations
+	[
+		CrewLocation
+	]
+}
+
+PartCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+}

--- a/starwars/swturret_B.rules
+++ b/starwars/swturret_B.rules
@@ -1,0 +1,36 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusOne]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[.5, 0.6875]
+	]
+	CrewLocations
+	[
+		CrewLocation
+	]
+}
+
+PartCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+}

--- a/starwars/swturret_C.rules
+++ b/starwars/swturret_C.rules
@@ -1,0 +1,36 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusOne]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[.5, 0.6875]
+	]
+	CrewLocations
+	[
+		CrewLocation
+	]
+}
+
+PartCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+}

--- a/starwars/turbolaser_ball_huge_roof_base.rules
+++ b/starwars/turbolaser_ball_huge_roof_base.rules
@@ -1,0 +1,227 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour, PartCrewMinusFive, PartCrewMinusSix]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, NeedsCrewMinusFour, NeedsCrewMinusFive, PartCrewMinusSix]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 6
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[1.546875, 3.59375]
+		[2.453125, 3.59375]
+		[6.453125, 3.59375]
+		[5.546875, 3.59375]
+		[3.546875, 5.59375]
+		[4.453125, 5.59375]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 5
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[1.546875, 3.59375]
+		[2.453125, 3.59375]
+		[6.453125, 3.59375]
+		[5.546875, 3.59375]
+		[3.546875, 5.59375]
+		[4.453125, 5.59375]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[1.546875, 3.59375]
+		[2.453125, 3.59375]
+		[6.453125, 3.59375]
+		[5.546875, 3.59375]
+		[3.546875, 5.59375]
+		[4.453125, 5.59375]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[1.546875, 3.59375]
+		[2.453125, 3.59375]
+		[6.453125, 3.59375]
+		[5.546875, 3.59375]
+		[3.546875, 5.59375]
+		[4.453125, 5.59375]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 4
+	MinBuffValue = 4
+}
+PartCrewMinusFour
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFour]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[1.546875, 3.59375]
+		[2.453125, 3.59375]
+		[6.453125, 3.59375]
+		[5.546875, 3.59375]
+		[3.546875, 5.59375]
+		[4.453125, 5.59375]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusFive
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 5
+	MinBuffValue = 5
+}
+PartCrewMinusFive
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Utility_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusFive]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[1.546875, 3.59375]
+		[2.453125, 3.59375]
+		[6.453125, 3.59375]
+		[5.546875, 3.59375]
+		[3.546875, 5.59375]
+		[4.453125, 5.59375]
+	]
+	CrewLocations
+	[
+		CrewLocation
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+		CrewLocation5
+		CrewLocation6
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusSix
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 6
+}

--- a/starwars/turbolaser_ball_large_roof_base.rules
+++ b/starwars/turbolaser_ball_large_roof_base.rules
@@ -1,0 +1,139 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[67/64, 229/64]
+		[125/64, 229/64]
+		[259/64, 229/64]
+		[317/64, 229/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[67/64, 229/64]
+		[125/64, 229/64]
+		[259/64, 229/64]
+		[317/64, 229/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[67/64, 229/64]
+		[125/64, 229/64]
+		[259/64, 229/64]
+		[317/64, 229/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[67/64, 229/64]
+		[125/64, 229/64]
+		[259/64, 229/64]
+		[317/64, 229/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 4
+}

--- a/starwars/turbolaser_ball_large_side_base.rules
+++ b/starwars/turbolaser_ball_large_side_base.rules
@@ -1,0 +1,139 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[67/64, 229/64]
+		[125/64, 229/64]
+		[259/64, 229/64]
+		[317/64, 229/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[67/64, 229/64]
+		[125/64, 229/64]
+		[259/64, 229/64]
+		[317/64, 229/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[67/64, 229/64]
+		[125/64, 229/64]
+		[259/64, 229/64]
+		[317/64, 229/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[67/64, 229/64]
+		[125/64, 229/64]
+		[259/64, 229/64]
+		[317/64, 229/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 4
+}

--- a/starwars/turbolaser_ball_med_roof_base.rules
+++ b/starwars/turbolaser_ball_med_roof_base.rules
@@ -1,0 +1,101 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, PartCrewMinusThree]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[99/64, 166/64]
+		[157/64, 166/64]
+		[2, 212/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[99/64, 166/64]
+		[157/64, 166/64]
+		[2, 212/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[99/64, 166/64]
+		[157/64, 166/64]
+		[2, 212/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 3
+}

--- a/starwars/turbolaser_ball_med_side_base.rules
+++ b/starwars/turbolaser_ball_med_side_base.rules
@@ -1,0 +1,101 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, PartCrewMinusThree]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[99/64, 166/64]
+		[157/64, 166/64]
+		[2, 212/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[99/64, 166/64]
+		[157/64, 166/64]
+		[2, 212/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/ControlRoom_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[99/64, 166/64]
+		[157/64, 166/64]
+		[2, 212/64]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 3
+}

--- a/starwars/turbolaser_ball_small01.rules
+++ b/starwars/turbolaser_ball_small01.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[0.55, 0.5]
+		[1.45, 0.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.55, 0.5]
+		[1.45, 0.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/turbolaser_ball_small02.rules
+++ b/starwars/turbolaser_ball_small02.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[0.55, 0.5]
+		[1.45, 0.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.55, 0.5]
+		[1.45, 0.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/turbolaser_ball_small03.rules
+++ b/starwars/turbolaser_ball_small03.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[0.55, 0.5]
+		[1.45, 0.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.55, 0.5]
+		[1.45, 0.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/turbolaser_carronade.rules
+++ b/starwars/turbolaser_carronade.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[0.55, 1.6]
+		[1.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.55, 1.6]
+		[1.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/turbolaser_flak_cannon01.rules
+++ b/starwars/turbolaser_flak_cannon01.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[1.55, 4.6]
+		[2.45, 4.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[1.55, 4.6]
+		[2.45, 4.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/turbolaser_large_base.rules
+++ b/starwars/turbolaser_large_base.rules
@@ -1,0 +1,139 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[3.46875, 2.15625]
+		[4.53125, 2.15625]
+		[3.640625, 3.265625]
+		[4.359375, 3.265625]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3.46875, 2.15625]
+		[4.53125, 2.15625]
+		[3.640625, 3.265625]
+		[4.359375, 3.265625]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3.46875, 2.15625]
+		[4.53125, 2.15625]
+		[3.640625, 3.265625]
+		[4.359375, 3.265625]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[3.46875, 2.15625]
+		[4.53125, 2.15625]
+		[3.640625, 3.265625]
+		[4.359375, 3.265625]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 4
+}

--- a/starwars/turbolaser_light_pd4.rules
+++ b/starwars/turbolaser_light_pd4.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[0.55, 0.5]
+		[1.45, 0.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.55, 0.5]
+		[1.45, 0.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/turbolaser_med_LR01.rules
+++ b/starwars/turbolaser_med_LR01.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[0.55, 0.5]
+		[1.45, 0.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.55, 0.5]
+		[1.45, 0.5]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/turbolaser_medium_base.rules
+++ b/starwars/turbolaser_medium_base.rules
@@ -1,0 +1,139 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo, PartCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, NeedsCrewMinusTwo, NeedsCrewMinusThree, PartCrewMinusFour]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 4
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[0.546875, 2.59375]
+		[1.453125, 2.59375]
+		[5.453125, 2.59375]
+		[4.546875, 2.59375]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 3
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.546875, 2.59375]
+		[1.453125, 2.59375]
+		[5.453125, 2.59375]
+		[4.546875, 2.59375]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 2
+	MinBuffValue = 2
+}
+PartCrewMinusTwo
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusTwo]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.546875, 2.59375]
+		[1.453125, 2.59375]
+		[5.453125, 2.59375]
+		[4.546875, 2.59375]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+NeedsCrewMinusThree
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 3
+	MinBuffValue = 3
+}
+PartCrewMinusThree
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusThree]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.546875, 2.59375]
+		[1.453125, 2.59375]
+		[5.453125, 2.59375]
+		[4.546875, 2.59375]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+		CrewLocation3
+		CrewLocation4
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusFour
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 4
+}

--- a/starwars/turbolaser_spinal_turret_2x3.rules
+++ b/starwars/turbolaser_spinal_turret_2x3.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[0.55, 1.6]
+		[1.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[0.55, 1.6]
+		[1.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/turbolaser_tower_triple01.rules
+++ b/starwars/turbolaser_tower_triple01.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[1.55, 1.6]
+		[2.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[1.55, 1.6]
+		[2.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}

--- a/starwars/xx9_turbolaser_switchable.rules
+++ b/starwars/xx9_turbolaser_switchable.rules
@@ -1,0 +1,67 @@
+PartCrew
+{
+	Type = MultiToggle
+	Toggles = [PartCrewMinusNone, PartCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+}
+
+NeedsCrewMinusNone
+{
+	Type = MultiToggle
+	Toggles = [NeedsCrewMinusOne, PartCrewMinusTwo]
+	Mode = Any
+	Invert = True
+}
+PartCrewMinusNone
+{
+	Type = PartCrew
+	Crew = 2
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusNone]
+	HighPriorityPrerequisites = [BatteryStorage]
+	CrewDestinations
+	[
+		[1.55, 1.6]
+		[2.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+}
+
+NeedsCrewMinusOne
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MaxBuffValue = 1
+	MinBuffValue = 1
+}
+PartCrewMinusOne
+{
+	Type = PartCrew
+	Crew = 1
+	DefaultPriority = &/PRIORITIES/Weapon_Crew
+	PrerequisitesBeforeCrewing = [PowerToggle, NeedsCrewMinusOne]
+	HighPriorityPrerequisites = [BatteryStorage]
+	OverridePriorityKey = PartCrewMinusNone
+	CrewDestinations
+	[
+		[1.55, 1.6]
+		[2.45, 1.6]
+	]
+	CrewLocations
+	[
+		CrewLocation1
+		CrewLocation2
+	]
+	SwitchLocationInterval = [5, 10]
+}
+
+PartCrewMinusTwo
+{
+	Type = BuffToggle
+	BuffType = AephixAITerminal
+	MinBuffValue = 2
+}


### PR DESCRIPTION
- Rules and files added for one component from SW factions - the small PD lasers (1 crew)
- Rules and files added for most Star Wars ACD components including war room, command bridge, and all blasters
- Rules and files added for the More Cannons mod for automating massive guns